### PR TITLE
Sync pnpm version across GitHub Actions workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,8 +15,6 @@ jobs:
     
     - name: Install pnpm
       uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9
         
     - name: Setup Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         
     - name: Install pnpm
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
       with:
         version: 9
         
@@ -30,7 +30,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -20,8 +20,6 @@ jobs:
         
     - name: Install pnpm
       uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-      with:
-        version: 9
         
     - name: Get pnpm store directory
       id: pnpm-cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0


### PR DESCRIPTION
## Summary
- Remove hardcoded pnpm version from GitHub Actions workflows
- Enable automatic version sync via packageManager field in package.json
- Ensure consistent pnpm version management across all workflows

## Changes
- Removed `version: 9` from pnpm/action-setup in e2e.yaml, test.yaml, and storybook.yaml
- Workflows now automatically use the version specified in package.json's packageManager field
- Enables Renovate to manage pnpm version updates centrally

## Test plan
- [x] E2E tests workflow should use pnpm@10.12.2 from package.json
- [x] Unit tests workflow should use pnpm@10.12.2 from package.json  
- [x] Storybook workflow should use pnpm@10.12.2 from package.json
- [x] All workflows should continue to work without explicit version specification

🤖 Generated with [Claude Code](https://claude.ai/code)