### PR TITLE
ci: apply zizmor security fixes to workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,6 +12,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     
     - name: Install pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - run: corepack enable
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -39,7 +41,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
-          gh release create "${{ env.SNACK_TIME_VERSION }}"
-          snack_time.zip#"snack-time-${{ env.SNACK_TIME_VERSION }}.zip"
+          gh release create "${SNACK_TIME_VERSION}"
+          snack_time.zip#"snack-time-${SNACK_TIME_VERSION}.zip"
           --generate-notes
-          --title "Release ${{ env.SNACK_TIME_VERSION }}"
+          --title "Release ${SNACK_TIME_VERSION}"

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -12,6 +12,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10


### PR DESCRIPTION
## Changes

- Add `persist-credentials: false` to every `actions/checkout` step.
- **[Needs review] `release.yaml`: template-injection fix rewrites `${{ env.SNACK_TIME_VERSION }}` to the shell expansion `${SNACK_TIME_VERSION}`. This can change behavior, so please review it.**

Applies the auto-fixes from zizmor 1.25.2 using `--fix=all`.

## Background

`--fix=safe` applies nothing here: the `artipacked` (persist-credentials) auto-fix is classified as unsafe, so every fix is held back in safe mode. `--fix=all` is used instead.

## Notes

- SHA pinning is out of scope — it is delegated to Renovate (`config:best-practices`).
- `excessive-permissions` findings have no auto-fix and are handled separately, per job.
- None of the affected workflows run `git push`; they all pass `secrets.GITHUB_TOKEN` explicitly, so `persist-credentials: false` is not expected to break anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
