### PR TITLE
ci: add minimal permissions and default shell

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

- Add a top-level `permissions: contents: read` to `e2e.yaml`, `storybook.yaml` and `test.yaml`. All three only read the repository.
- Add `defaults.run.shell: bash` to the same three workflows.

Follow-up to the zizmor hardening pass. `defaults.run.shell: bash` is not covered by zizmor and is applied here for consistency across workflows.

Verified with `actionlint` (no new findings) and a zizmor re-run.

zizmor `excessive-permissions`: 3 findings -> 0. `release.yaml` is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
