### PR TITLE
ci: add a timeout to the E2E job

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,8 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 15
+
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:


### PR DESCRIPTION
## Changes

- Add `timeout-minutes: 15` to the `test` job.

## Why

The E2E job hung for 60 minutes today in [run 32210186846](https://github.com/corrupt952/SnackTime/actions/runs/32210186846). `playwright install-deps` runs `apt-get update` internally, which could not reach the `azure.archive.ubuntu.com` mirror, fell back to `archive.ubuntu.com`, and then produced no output at all for 59 minutes. It never reached `Fetched` or `Reading package lists...`.

The cause was a transient mirror outage, not anything in this repository: re-running the exact same commit succeeded, with that step finishing in 23 seconds.

The real problem is that the job had no `timeout-minutes`, so the [default of 360 minutes](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes) applied and the run would have burned six hours of runner time before being killed. Past successful runs of this job take 4-5 minutes, so 15 minutes leaves roughly a 3x margin.

## Follow-up

Hardening the Playwright setup itself — either making the `apt` step resilient or moving to the official `mcr.microsoft.com/playwright` container image, which removes the `apt-get` dependency entirely — is being evaluated separately and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
