### PR TITLE
ci: guard the release step and disable caching

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,19 +29,21 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: "pnpm"
+          package-manager-cache: false
       - name: Export current version
-        run: echo "SNACK_TIME_VERSION=v$(jq -r .version package.json)" > $GITHUB_ENV
+        run: echo "SNACK_TIME_VERSION=v$(jq -r .version package.json)" >> $GITHUB_ENV
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: >-
           cd .output/chrome-mv3 && \
             zip -r ../../snack_time.zip ./*
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           gh release create "${SNACK_TIME_VERSION}"
           snack_time.zip#"snack-time-${SNACK_TIME_VERSION}.zip"
+          --verify-tag
           --generate-notes
           --title "Release ${SNACK_TIME_VERSION}"


### PR DESCRIPTION
## Changes

- Guard the `Create Release` step with `if: startsWith(github.ref, 'refs/tags/')`.
- Add `--verify-tag` to `gh release create`.
- Disable `actions/setup-node` package manager caching in this workflow (`package-manager-cache: false`), and drop the explicit `cache: "pnpm"`.
- Fix `> $GITHUB_ENV` to `>> $GITHUB_ENV`.

## Why

This workflow has `workflow_dispatch` but nothing tied the release to a tag. `SNACK_TIME_VERSION` comes from `package.json`, not from `github.ref`, so dispatching this workflow on **any** branch would create a real release as long as that version had not been released yet. `gh release create` does not fail when the tag is missing — it [creates the tag automatically from the latest state of the default branch](https://cli.github.com/manual/gh_release_create).

The `if:` is the primary guard: a manual dispatch now builds and zips, then skips the release. Dispatching against a tag ref still releases, so the manual recovery path is intact. `--verify-tag` is a second layer — it aborts if the tag does not already exist remotely, so the dangerous auto-tag behavior is off even if the condition is ever removed or broken.

Caching is disabled because a release workflow restoring a cache written by another run is the [cache-poisoning](https://docs.zizmor.sh/audits/#cache-poisoning) risk zizmor flags. `package-manager-cache` [defaults to true](https://github.com/actions/setup-node/blob/820762786026740c76f36085b0efc47a31fe5020/action.yml) in setup-node v7, so it has to be turned off explicitly.

The `>` to `>>` fix is unrelated but adjacent: writing to `$GITHUB_ENV` with a single `>` truncates the file. Nothing else writes to it today, so there is no current bug, but it breaks the moment a second step does.

## Verification

`actionlint` reports no new findings and zizmor now reports zero findings for this repository. Note that this workflow is **not** exercised by pull request CI — it only triggers on tag pushes and manual dispatch — so these changes are verified statically, not by a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
