### PR TITLE
ci: run E2E tests in the Playwright container image

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,30 +18,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
+    container:
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
+      options: --user 1001 --ipc=host
+
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    
+
     - name: Install pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        
+
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '24'
         cache: 'pnpm'
-          
+
     - name: Install dependencies
       run: pnpm install
-      
-    - name: Install Playwright browsers and dependencies
-      run: |
-        pnpm exec playwright install chromium
-        pnpm exec playwright install-deps chromium
-      
+      timeout-minutes: 5
+
     - name: Run E2E tests
       run: xvfb-run -a pnpm test:e2e
+      timeout-minutes: 10
       env:
         CI: true
-        


### PR DESCRIPTION
## Changes

- Run the E2E job inside `mcr.microsoft.com/playwright:v1.62.1-noble`.
- Remove the `Install Playwright browsers and dependencies` step.
- Add step-level timeouts to `Install dependencies` (5 min) and `Run E2E tests` (10 min).

## Why

`playwright install-deps` runs `sudo apt-get update` internally, and the Ubuntu mirrors it depends on have been failing repeatedly. Three E2E runs hung at that exact step within six minutes of each other today — on `main`, on a Renovate branch, and on a CI branch — each stalling with no output after `apt` fell back from `azure.archive.ubuntu.com` to `archive.ubuntu.com`. All three were killed by the `timeout-minutes: 15` added in #537. An earlier run the same day hung for 60 minutes before that timeout existed.

The official Playwright image already has the browsers and their system dependencies baked in, with `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`, so this job stops touching `apt` at all and the failure mode disappears rather than being retried around.

## Details

`options: --user 1001` is what [Playwright's own GitHub Actions example](https://github.com/microsoft/playwright/blob/main/docs/src/ci.md) uses. `--ipc=host` is [recommended by the Playwright Docker guide](https://playwright.dev/docs/docker#recommended-docker-configuration), which notes Chromium can run out of memory without it.

The workflow-level `defaults.run.shell: bash` matters more now and must stay: the [default shell for `run` steps inside a container is `sh`, not `bash`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idcontainer).

`xvfb-run` is still needed and is present in the image. `actions/setup-node` is kept for the `cache: 'pnpm'` store cache; the image ships Node 24, which matches `node-version: '24'`. `actions/checkout` works normally because the image includes `git` and `openssh-client`.

Renovate should pick the image up through the `docker` manager and, with `docker:pinDigests` from `config:best-practices`, follow up with a PR pinning it to a digest. That pin is expected, not something to add by hand here.

Note that the image tag has to move together with the `playwright` version in `package.json`. If they drift, the browsers baked into the image will not match what the npm package expects.

## Verification

`actionlint` and `zizmor --offline` both report no findings. The real check is this PR's own E2E run: if the image tag were wrong the job would fail immediately at `Initialize containers`, and if the browsers were missing the tests would fail outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
