### PR TITLE
fix: make the release step idempotent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,9 +42,17 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          gh release create "${SNACK_TIME_VERSION}"
-          snack_time.zip#"snack-time-${SNACK_TIME_VERSION}.zip"
-          --verify-tag
-          --generate-notes
-          --title "Release ${SNACK_TIME_VERSION}"
+        run: |
+          if [ "${SNACK_TIME_VERSION}" != "${GITHUB_REF_NAME}" ]; then
+            echo "tag ${GITHUB_REF_NAME} does not match package.json version ${SNACK_TIME_VERSION}" >&2
+            exit 1
+          fi
+          asset="snack_time.zip#snack-time-${GITHUB_REF_NAME}.zip"
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" "${asset}" --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" "${asset}" \
+              --verify-tag \
+              --generate-notes \
+              --title "Release ${GITHUB_REF_NAME}"
+          fi


### PR DESCRIPTION
## Changes

- Derive the release tag from `GITHUB_REF_NAME` instead of `package.json`, and fail loudly when the two disagree.
- Make the release step idempotent (see below).

## Why

`softprops/action-gh-release`, which this workflow used until earlier today, updates an existing release rather than failing: *"If a tag already has a GitHub release, the existing release will be updated with the release assets"* ([README](https://github.com/softprops/action-gh-release/blob/3d0d9888cb7fd7b750713d6e236d1fcb99157228/README.md)). `gh release create` fails instead — observed for real in [this run](https://github.com/corrupt952/SnackTime/actions/runs/32208348696): `a release with the same tag name already exists`.

Replacing the action therefore removed the ability to re-run a release after a partial failure. If an asset upload dies on a network error, the old setup recovered on re-run; the new one failed until the release was deleted by hand. All three release workflows have `workflow_dispatch`, so re-running is a real path, not a hypothetical.

Checking for an existing release and falling back to `gh release upload --clobber` restores that. The `--verify-tag` guard stays on the create path.

This is a regression I introduced today and did not flag in the PR that made the switch.

## The tag source change

`SNACK_TIME_VERSION` comes from `package.json`, so pushing tag `v2026.05.1` while `package.json` still says `2026.04.2` made `gh` target `v2026.04.2`. That old tag exists on the remote, so `--verify-tag` passed and the failure only surfaced as a collision with the existing release — a confusing way to break. `SnackCards` and `nooon` already use `GITHUB_REF_NAME`; this aligns the three.

The explicit comparison turns a silent mismatch into a one-line error naming both values.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
