### PR TITLE
ci: enforce zizmor in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,3 +42,15 @@ jobs:
       - name: Build extension
         run: pnpm build
 
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
## Changes

- Add a `zizmor` job to the existing CI workflow.

## Why

Every workflow in this account is currently clean under `zizmor` (56 findings were fixed across 12 repositories today), but nothing keeps it that way. Only 4 of 12 repositories ran zizmor in CI, so the next workflow anyone adds — including Renovate — can reintroduce a finding silently.

This uses the same pinned action and job shape already in use in `sallyport`, `dotfiles`, `xckit` and `closest`.

Verified with `actionlint` and a local `zizmor --offline` run over the repository including this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
