### PR TITLE
ci: pin the Playwright container image to its digest

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
 
     container:
-      image: mcr.microsoft.com/playwright:v1.62.1-noble
+      image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
       options: --user 1001 --ipc=host
 
     steps:


### PR DESCRIPTION
## Changes

- Pin the Playwright container image to its digest.

```diff
-      image: mcr.microsoft.com/playwright:v1.62.1-noble
+      image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e...
```

## Why

`v1.62.1-noble` is a mutable tag. Registry tags can be re-pushed to point at different content, which is the same class of exposure that SHA pinning closes for actions — and this container runs every E2E job with the repository checked out into it.

Renovate's `docker:pinDigests` (via `config:best-practices`) would do this, but it runs on Mondays, so the tag stays mutable until then. Pinning by hand now; Renovate will keep the digest current from here.

The digest comes from the `docker pull` in [the last successful run on `main`](https://github.com/corrupt952/SnackTime/actions/runs/32224651579), so it is what CI has actually been executing:

```
Digest: sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
Status: Downloaded newer image for mcr.microsoft.com/playwright:v1.62.1-noble
```

This PR's own E2E run verifies it: a wrong digest fails immediately at `Initialize containers`.

Note that the digest and the `playwright` version in `package.json` must move together. Renovate handles both, but a manual bump to one needs the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
