### PR TITLE
ci: add concurrency groups to workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: Release
 
 concurrency:
-  group: "release"
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Changes

- Add `concurrency` to `e2e.yaml`, `storybook.yaml` and `test.yaml`.
- Flip `release.yaml` to `cancel-in-progress: false` and give it a per-ref group.

## Why

Without a `concurrency` group, pushing to a PR leaves the previous run going, so several runs of the same workflow race for the same commit range. `sallyport` and `dotfiles` already use the CI form below; this brings the rest in line.

For CI and lint workflows, cancelling the older run is the point:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

For release and deploy workflows the opposite is true — interrupting one halfway can leave a partial release or a half-finished deployment — so those get `cancel-in-progress: false`.

Verified with `actionlint` and `zizmor --offline`.

`release.yaml` previously used `group: "release"` with `cancel-in-progress: true`, so pushing two tags in a row would abort the first release mid-flight.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
