### PR TITLE
ci: drop unused id-token permission and narrow release scope

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 defaults:
   run:
@@ -22,6 +21,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Changes

- Drop `id-token: write` from the workflow.
- Narrow the top-level `permissions` to `contents: read`, and grant `contents: write` to the `build` job.

## Why

`id-token: write` was never used. Nothing in this workflow requests an OIDC token — no cloud login action, no `getIDToken`, no `ACTIONS_ID_TOKEN_REQUEST_*` consumer. It was granting the ability to mint an identity token for a workflow that has no use for one.

Moving `contents: write` down to the job is currently equivalent, since this workflow has a single job. It matters the moment a second job is added: a lint or verification job would otherwise inherit write access to the repository contents for no reason. This also matches the shape used in `nooon`, `home` and `zuki.dev`, where the elevated scope sits on the job that needs it.

Verified with `actionlint` and `zizmor --offline`. Note this workflow only runs on tag pushes and manual dispatch, so it is not exercised by pull request CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
