### PR TITLE
ci: simplify the release step back to gh release create

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,12 +48,8 @@ jobs:
             echo "tag ${GITHUB_REF_NAME} does not match package.json version ${SNACK_TIME_VERSION}" >&2
             exit 1
           fi
-          asset="snack_time.zip#snack-time-${GITHUB_REF_NAME}.zip"
-          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release upload "${GITHUB_REF_NAME}" "${asset}" --clobber
-          else
-            gh release create "${GITHUB_REF_NAME}" "${asset}" \
-              --verify-tag \
-              --generate-notes \
-              --title "Release ${GITHUB_REF_NAME}"
-          fi
+          gh release create "${GITHUB_REF_NAME}" \
+            "snack_time.zip#snack-time-${GITHUB_REF_NAME}.zip" \
+            --verify-tag \
+            --generate-notes \
+            --title "Release ${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Changes

- Drop the `gh release upload --clobber` fallback and go back to a plain `gh release create`.

## Why

I added that fallback earlier today, on the reasoning that replacing `softprops/action-gh-release` with `gh release create` had removed the ability to recover from a release that failed partway. That reasoning was wrong.

`gh release create` does not leave a half-finished release behind. When there are assets, it creates the release as a draft, uploads everything, and only then publishes — and deletes the draft if any step fails. This is documented in `gh`'s own help text:

> Immutability is enforced only after a release is published. … are made to create the release as a draft, upload the assets, and then publish the release.

So the branch only ever runs when a *published* release already exists for the tag, which is not a recovery case — it is overwriting a release that has already shipped. Removing it takes out a path that can only be reached by doing something the release process should not be doing anyway.

`--verify-tag` and the `if: startsWith(github.ref, 'refs/tags/')` guard are unchanged.

## Verification

`actionlint` and `zizmor --offline` are clean. This workflow only runs on tag pushes and manual dispatch, so it is not exercised by pull request CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
