### PR TITLE
ci: run pnpm compile in the Unit Tests job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Type check
+        run: pnpm compile
+
       - name: Run unit tests
         run: pnpm test
 


### PR DESCRIPTION
## Problem

The README rewritten in #549 says the Checks section lists "the same commands CI runs", and includes `Type check: pnpm compile`. CI does not run it. The Unit Tests job runs `pnpm test` and `pnpm build`; `pnpm compile` appears nowhere in `ci.yaml`.

So the README states a guarantee that does not exist: a type error can reach `main` with every check green.

## Change

Run `pnpm compile` in the Unit Tests job, before `pnpm test`. The script already exists in `package.json` as `tsc --noEmit`.

This makes the README accurate rather than editing the claim out, and matches SnackCards, whose check job runs `pnpm compile` (restored in SnackCards#182).

`CI Result` already lists `test` in `needs`, so a type failure blocks the required check with no ruleset change.

## Verification

Whether `tsc --noEmit` currently passes on `main` was not verified before opening this PR - the CI run here is the check. If it fails, the type errors are pre-existing and need fixing before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
